### PR TITLE
1.19.3 update

### DIFF
--- a/DataGenerator/src/main/java/net/minestom/generators/AttributeGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/AttributeGenerator.java
@@ -1,7 +1,7 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.ai.attributes.RangedAttribute;
 import net.minestom.datagen.DataGenerator;
 
@@ -9,8 +9,9 @@ public final class AttributeGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject attributes = new JsonObject();
-        for (var attribute : Registry.ATTRIBUTE) {
-            final var location = Registry.ATTRIBUTE.getKey(attribute);
+        var registry = BuiltInRegistries.ATTRIBUTE;
+        for (var attribute : registry) {
+            final var location = registry.key().location();
             JsonObject attributeJson = new JsonObject();
             attributeJson.addProperty("translationKey", attribute.getDescriptionId());
             attributeJson.addProperty("defaultValue", attribute.getDefaultValue());

--- a/DataGenerator/src/main/java/net/minestom/generators/BannerPatternGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/BannerPatternGenerator.java
@@ -2,7 +2,7 @@ package net.minestom.generators;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.block.entity.BannerPattern;
 import net.minestom.datagen.DataGenerator;
 
@@ -11,11 +11,12 @@ public class BannerPatternGenerator extends DataGenerator {
     @Override
     public JsonElement generate() throws Exception {
         JsonObject patternTypes = new JsonObject();
-        for (BannerPattern bannerPattern : Registry.BANNER_PATTERN) {
+        var registry = BuiltInRegistries.BANNER_PATTERN;
+        for (BannerPattern bannerPattern : registry) {
             JsonObject pattern = new JsonObject();
-            pattern.addProperty("id", Registry.BANNER_PATTERN.getId(bannerPattern));
+            pattern.addProperty("id", registry.getId(bannerPattern));
             pattern.addProperty("identifier", bannerPattern.getHashname());
-            patternTypes.add(Registry.BANNER_PATTERN.getKey(bannerPattern).toString(), pattern);
+            patternTypes.add(registry.getKey(bannerPattern).toString(), pattern);
         }
         return patternTypes;
     }

--- a/DataGenerator/src/main/java/net/minestom/generators/BiomeGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/BiomeGenerator.java
@@ -1,17 +1,29 @@
 package net.minestom.generators;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import net.minecraft.data.BuiltinRegistries;
+import net.minecraft.world.level.biome.*;
 import net.minestom.datagen.DataGenerator;
+import net.minestom.utils.ResourceUtils;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.*;
 
 public final class BiomeGenerator extends DataGenerator {
 
+    private static final String BIOMES_DIR = "data/minecraft/worldgen/biome/";
+    private static final Gson gson = new Gson();
+
     @Override
     public JsonObject generate() throws Exception {
-        JsonObject biomes = new JsonObject();
-        for (var biome : BuiltinRegistries.BIOME) {
-            final var location = BuiltinRegistries.BIOME.getKey(biome);
+        var biomesJson = new JsonObject();
+        var biomes = readBiomes();
+
+        for (var entry : biomes.entrySet()) {
+            var biome = entry.getValue();
             JsonObject biomeJson = new JsonObject();
+
             biomeJson.addProperty("humid", biome.isHumid());
 //            biomeJson.addProperty("scale", biome.dep);
 //            biomeJson.addProperty("depth", biome.getDepth());
@@ -27,8 +39,71 @@ public final class BiomeGenerator extends DataGenerator {
             biomeJson.addProperty("foliageColorOverride", biome.getSpecialEffects().getFoliageColorOverride().orElse(null));
             biomeJson.addProperty("grassColorOverride", biome.getSpecialEffects().getGrassColorOverride().orElse(null));
             biomeJson.addProperty("grassColorModifier", biome.getSpecialEffects().getGrassColorModifier().getSerializedName());
-            biomes.add(location.toString(), biomeJson);
+            biomesJson.add("minecraft:" + entry.getKey(), biomeJson);
         }
-        return biomes;
+
+        return biomesJson;
+    }
+
+    private Map<String, Biome> readBiomes() throws URISyntaxException, IOException {
+        // get all files from the biomes directory
+        var files = ResourceUtils.getResourceListing(
+                net.minecraft.server.MinecraftServer.class, BIOMES_DIR);
+
+        Map<String, Biome> biomesJson = new HashMap<>();
+        for (String fileName : files) {
+            var file = net.minecraft.server.MinecraftServer.class
+                    .getClassLoader()
+                    .getResourceAsStream(BIOMES_DIR + fileName);
+            var scanner = new Scanner(file);
+            var content = new StringBuilder();
+            while (scanner.hasNextLine()) {
+                content.append(scanner.nextLine());
+            }
+            scanner.close();
+
+            // only collect valid biome files
+            if (content.length() > 0 && fileName.endsWith(".json")) {
+                var biomeKey = "minecraft:" + fileName.substring(0, fileName.length() - 5);
+                var jsonObject = gson.fromJson(content.toString(), JsonObject.class);
+                biomesJson.put(biomeKey, jsonToBiome(jsonObject));
+            }
+        }
+
+        return biomesJson;
+    }
+
+    private Biome jsonToBiome(JsonObject json) {
+        var effectsJson = json.get("effects").getAsJsonObject();
+        var effects = new BiomeSpecialEffects.Builder()
+                .fogColor(effectsJson.get("fog_color").getAsInt())
+                .waterColor(effectsJson.get("water_color").getAsInt())
+                .waterFogColor(effectsJson.get("water_fog_color").getAsInt())
+                .skyColor(effectsJson.get("sky_color").getAsInt());
+
+        if (effectsJson.has("foliage_color")) {
+            effects = effects.foliageColorOverride(effectsJson.get("foliage_color").getAsInt());
+        }
+
+        if (effectsJson.has("grass_color")) {
+            effects = effects.grassColorOverride(
+                    effectsJson.get("grass_color").getAsInt()
+            );
+        }
+
+        if (effectsJson.has("grass_color_modifier")) {
+            effects = effects.grassColorModifier(
+                    BiomeSpecialEffects.GrassColorModifier.valueOf(effectsJson.get("grass_color_modifier").getAsString().toUpperCase())
+            );
+        }
+
+        return new Biome.BiomeBuilder()
+                .temperature(json.get("temperature").getAsFloat())
+                .downfall(json.get("downfall").getAsFloat())
+                .precipitation(Biome.Precipitation.valueOf(json.get("precipitation").getAsString().toUpperCase()))
+                .specialEffects(effects.build())
+                .mobSpawnSettings(MobSpawnSettings.EMPTY)
+                .generationSettings(BiomeGenerationSettings.EMPTY)
+                .build();
     }
 }

--- a/DataGenerator/src/main/java/net/minestom/generators/CommandArgumentGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/CommandArgumentGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class CommandArgumentGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject arguments = new JsonObject();
-        for (var argument : Registry.COMMAND_ARGUMENT_TYPE) {
-            final var location = Registry.COMMAND_ARGUMENT_TYPE.getKey(argument);
+        var registry = BuiltInRegistries.COMMAND_ARGUMENT_TYPE;
+        for (var argument : registry) {
+            final var location = registry.getKey(argument);
             JsonObject object = new JsonObject();
-            object.addProperty("id", Registry.COMMAND_ARGUMENT_TYPE.getId(argument));
+            object.addProperty("id", registry.getId(argument));
             arguments.add(location.toString(), object);
         }
         return arguments;

--- a/DataGenerator/src/main/java/net/minestom/generators/CustomStatisticGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/CustomStatisticGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class CustomStatisticGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject customStatistics = new JsonObject();
-        for (var stat : Registry.CUSTOM_STAT) {
-            final var location = Registry.CUSTOM_STAT.getKey(stat);
+        var registry = BuiltInRegistries.CUSTOM_STAT;
+        for (var stat : registry) {
+            final var location = registry.getKey(stat);
             JsonObject customStatistic = new JsonObject();
-            customStatistic.addProperty("id", Registry.CUSTOM_STAT.getId(stat));
+            customStatistic.addProperty("id", registry.getId(stat));
             customStatistics.add(location.toString(), customStatistic);
         }
         return customStatistics;

--- a/DataGenerator/src/main/java/net/minestom/generators/DimensionTypeGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/DimensionTypeGenerator.java
@@ -1,31 +1,70 @@
 package net.minestom.generators;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import net.minecraft.data.BuiltinRegistries;
 import net.minestom.datagen.DataGenerator;
+import net.minestom.utils.ResourceUtils;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
 
 public final class DimensionTypeGenerator extends DataGenerator {
+
+    private static final String DIMENSION_TYPES_DIR = "data/minecraft/dimension_type/";
+    private static final Gson gson = new Gson();
+
     @Override
-    public JsonObject generate() {
-        JsonObject dimensionTypes = new JsonObject();
-        for (var dimensionType : BuiltinRegistries.DIMENSION_TYPE) {
-            final var location = BuiltinRegistries.DIMENSION_TYPE.getKey(dimensionType);
-            JsonObject dimensionTypeJson = new JsonObject();
-            dimensionTypeJson.addProperty("bedWorks", dimensionType.bedWorks());
-            dimensionTypeJson.addProperty("coordinateScale", dimensionType.coordinateScale());
-            dimensionTypeJson.addProperty("ceiling", dimensionType.hasCeiling());
-            dimensionTypeJson.addProperty("fixedTime", dimensionType.hasFixedTime());
-            dimensionTypeJson.addProperty("raids", dimensionType.hasRaids());
-            dimensionTypeJson.addProperty("skyLight", dimensionType.hasSkyLight());
-            dimensionTypeJson.addProperty("piglinSafe", dimensionType.piglinSafe());
-            dimensionTypeJson.addProperty("logicalHeight", dimensionType.logicalHeight());
-            dimensionTypeJson.addProperty("natural", dimensionType.natural());
-            dimensionTypeJson.addProperty("ultraWarm", dimensionType.ultraWarm());
-            dimensionTypeJson.addProperty("respawnAnchorWorks", dimensionType.respawnAnchorWorks());
-            dimensionTypeJson.addProperty("minY", dimensionType.minY());
-            dimensionTypeJson.addProperty("height", dimensionType.height());
-            dimensionTypes.add(location.toString(), dimensionTypeJson);
+    public JsonObject generate() throws Exception {
+        var dimensionTypesJson = new JsonObject();
+        var dimensionTypes = readDimensionTypes();
+        for (var entry : dimensionTypes.entrySet()) {
+            dimensionTypesJson.add(entry.getKey(), entry.getValue());
         }
-        return dimensionTypes;
+        return dimensionTypesJson;
+    }
+
+    private Map<String, JsonObject> readDimensionTypes() throws URISyntaxException, IOException {
+        // get all files from the dimension types directory
+        var files = ResourceUtils.getResourceListing(
+                net.minecraft.server.MinecraftServer.class, DIMENSION_TYPES_DIR);
+
+        Map<String, JsonObject> dimensionTypesJson = new HashMap<>();
+        for (String fileName : files) {
+            var file = net.minecraft.server.MinecraftServer.class
+                    .getClassLoader()
+                    .getResourceAsStream(DIMENSION_TYPES_DIR + fileName);
+            var scanner = new Scanner(file);
+            var content = new StringBuilder();
+            while (scanner.hasNextLine()) {
+                content.append(scanner.nextLine());
+            }
+            scanner.close();
+
+            // only collect valid dimension type files
+            if (content.length() > 0 && fileName.endsWith(".json")) {
+                var biomeKey = "minecraft:" + fileName.substring(0, fileName.length() - 5);
+                var json = gson.fromJson(content.toString(), JsonObject.class);
+                var dimensionType = new JsonObject();
+                dimensionType.addProperty("bedWorks", json.get("bed_works").getAsBoolean());
+                dimensionType.addProperty("coordinateScale", json.get("coordinate_scale").getAsDouble());
+                dimensionType.addProperty("ceiling", json.get("has_ceiling").getAsBoolean());
+                dimensionType.addProperty("fixedTime", json.has("fixed_time"));
+                dimensionType.addProperty("raids", json.get("has_raids").getAsBoolean());
+                dimensionType.addProperty("skyLight", json.get("has_skylight").getAsBoolean());
+                dimensionType.addProperty("piglinSafe", json.get("piglin_safe").getAsBoolean());
+                dimensionType.addProperty("logicalHeight", json.get("logical_height").getAsInt());
+                dimensionType.addProperty("natural", json.get("natural").getAsBoolean());
+                dimensionType.addProperty("ultraWarm", json.get("ultrawarm").getAsBoolean());
+                dimensionType.addProperty("respawnAnchorWorks", json.get("respawn_anchor_works").getAsBoolean());
+                dimensionType.addProperty("minY", json.get("min_y").getAsInt());
+                dimensionType.addProperty("height", json.get("height").getAsInt());
+                dimensionTypesJson.put(biomeKey, dimensionType);
+            }
+        }
+
+        return dimensionTypesJson;
     }
 }

--- a/DataGenerator/src/main/java/net/minestom/generators/EnchantmentGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/EnchantmentGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class EnchantmentGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject enchantments = new JsonObject();
-        for (var enchantment : Registry.ENCHANTMENT) {
-            final var location = Registry.ENCHANTMENT.getKey(enchantment);
+        var registry = BuiltInRegistries.ENCHANTMENT;
+        for (var enchantment : registry) {
+            final var location = registry.getKey(enchantment);
             JsonObject enchantmentJson = new JsonObject();
-            enchantmentJson.addProperty("id", Registry.ENCHANTMENT.getId(enchantment));
+            enchantmentJson.addProperty("id", registry.getId(enchantment));
             enchantmentJson.addProperty("translationKey", enchantment.getDescriptionId());
             enchantmentJson.addProperty("maxLevel", enchantment.getMaxLevel());
             enchantmentJson.addProperty("rarity", enchantment.getRarity().toString());

--- a/DataGenerator/src/main/java/net/minestom/generators/EntityGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/EntityGenerator.java
@@ -1,7 +1,7 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.LivingEntity;
@@ -38,8 +38,9 @@ public final class EntityGenerator extends DataGenerator {
             }
         }
         JsonObject entities = new JsonObject();
-        for (var entityType : Registry.ENTITY_TYPE) {
-            final var location = Registry.ENTITY_TYPE.getKey(entityType);
+        var registry = BuiltInRegistries.ENTITY_TYPE;
+        for (var entityType : registry) {
+            final var location = registry.getKey(entityType);
             // Complicated but we need to get the Entity class of EntityType.
             // E.g. EntityType<T> we need to get T and check what classes T implements.
             final Class<?> entityClass = entityClasses.get(entityType);
@@ -56,7 +57,7 @@ public final class EntityGenerator extends DataGenerator {
                 packetType = "BASE";
             }
             JsonObject entity = new JsonObject();
-            entity.addProperty("id", Registry.ENTITY_TYPE.getId(entityType));
+            entity.addProperty("id", registry.getId(entityType));
             entity.addProperty("translationKey", entityType.getDescriptionId());
             entity.addProperty("packetType", packetType);
             addDefaultable(entity, "fireImmune", entityType.fireImmune(), false);

--- a/DataGenerator/src/main/java/net/minestom/generators/FluidGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/FluidGenerator.java
@@ -1,17 +1,19 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class FluidGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject fluids = new JsonObject();
-        for (var fluid : Registry.FLUID) {
-            final var location = Registry.FLUID.getKey(fluid);
+        var registry = BuiltInRegistries.FLUID;
+        var itemRegistry = BuiltInRegistries.ITEM;
+        for (var fluid : registry) {
+            final var location = registry.getKey(fluid);
             JsonObject fluidJson = new JsonObject();
-            fluidJson.addProperty("bucketId", Registry.ITEM.getKey(fluid.getBucket()).toString());
+            fluidJson.addProperty("bucketId", itemRegistry.getKey(fluid.getBucket()).toString());
             fluids.add(location.toString(), fluidJson);
         }
         return fluids;

--- a/DataGenerator/src/main/java/net/minestom/generators/GameEventGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/GameEventGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class GameEventGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject gameEvents = new JsonObject();
-        for (var gameEvent : Registry.GAME_EVENT) {
-            final var location = Registry.GAME_EVENT.getKey(gameEvent);
+        var registry = BuiltInRegistries.GAME_EVENT;
+        for (var gameEvent : registry) {
+            final var location = registry.getKey(gameEvent);
             JsonObject gameEventJson = new JsonObject();
-            gameEventJson.addProperty("id", Registry.GAME_EVENT.getId(gameEvent));
+            gameEventJson.addProperty("id", registry.getId(gameEvent));
             gameEventJson.addProperty("notificationRadius", gameEvent.getNotificationRadius());
             gameEvents.add(location.toString(), gameEventJson);
         }

--- a/DataGenerator/src/main/java/net/minestom/generators/MaterialGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/MaterialGenerator.java
@@ -3,7 +3,7 @@ package net.minestom.generators;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Pair;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.food.FoodProperties;
@@ -17,11 +17,16 @@ public final class MaterialGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject items = new JsonObject();
-        for (var item : Registry.ITEM) {
-            final var location = Registry.ITEM.getKey(item);
+        var registry = BuiltInRegistries.ITEM;
+        var blockRegistry = BuiltInRegistries.BLOCK;
+        var soundEventRegistry = BuiltInRegistries.SOUND_EVENT;
+        var mobEffectRegistry = BuiltInRegistries.MOB_EFFECT;
+        var entityTypeRegistry = BuiltInRegistries.ENTITY_TYPE;
+        for (var item : registry) {
+            final var location = registry.getKey(item);
 
             JsonObject itemJson = new JsonObject();
-            itemJson.addProperty("id", Registry.ITEM.getId(item));
+            itemJson.addProperty("id", registry.getId(item));
             itemJson.addProperty("translationKey", item.getDescriptionId());
             if (item.getMaxStackSize() != 64) { // Default = 64
                 itemJson.addProperty("maxStackSize", item.getMaxStackSize());
@@ -35,15 +40,15 @@ public final class MaterialGenerator extends DataGenerator {
             // Corresponding block
             Block block = Block.byItem(item);
             if (block != Blocks.AIR) { // Default = no block
-                itemJson.addProperty("correspondingBlock", Registry.BLOCK.getKey(block).toString());
+                itemJson.addProperty("correspondingBlock", blockRegistry.getKey(block).toString());
             }
             // Food properties
             if (item.isEdible()) { // Default = false (not edible)
                 itemJson.addProperty("edible", true);
-                ResourceLocation eatingSound = Registry.SOUND_EVENT.getKey(item.getEatingSound());
+                ResourceLocation eatingSound = soundEventRegistry.getKey(item.getEatingSound());
                 assert eatingSound != null;
                 itemJson.addProperty("eatingSound", eatingSound.toString());
-                ResourceLocation drinkingSound = Registry.SOUND_EVENT.getKey(item.getDrinkingSound());
+                ResourceLocation drinkingSound = soundEventRegistry.getKey(item.getDrinkingSound());
                 assert drinkingSound != null;
                 itemJson.addProperty("drinkingSound", drinkingSound.toString());
 
@@ -60,7 +65,7 @@ public final class MaterialGenerator extends DataGenerator {
                         for (Pair<MobEffectInstance, Float> effectEntry : foodProperties.getEffects()) {
                             final var effect = effectEntry.getFirst();
                             final var chance = effectEntry.getSecond();
-                            ResourceLocation rl = Registry.MOB_EFFECT.getKey(effect.getEffect());
+                            ResourceLocation rl = mobEffectRegistry.getKey(effect.getEffect());
                             if (rl == null) {
                                 continue;
                             }
@@ -87,7 +92,7 @@ public final class MaterialGenerator extends DataGenerator {
             // SpawnEgg properties
             if (item instanceof SpawnEggItem spawnEggItem) {
                 JsonObject spawnEggProperties = new JsonObject();
-                spawnEggProperties.addProperty("entityType", Registry.ENTITY_TYPE.getKey(spawnEggItem.getType(null)).toString());
+                spawnEggProperties.addProperty("entityType", entityTypeRegistry.getKey(spawnEggItem.getType(null)).toString());
                 itemJson.add("spawnEggProperties", spawnEggProperties);
             }
             items.add(location.toString(), itemJson);

--- a/DataGenerator/src/main/java/net/minestom/generators/MobEffectGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/MobEffectGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class MobEffectGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject effects = new JsonObject();
-        for (var mobEffect : Registry.MOB_EFFECT) {
-            final var location = Registry.MOB_EFFECT.getKey(mobEffect);
+        var registry = BuiltInRegistries.MOB_EFFECT;
+        for (var mobEffect : registry) {
+            final var location = registry.getKey(mobEffect);
             JsonObject effect = new JsonObject();
-            effect.addProperty("id", Registry.MOB_EFFECT.getId(mobEffect));
+            effect.addProperty("id", registry.getId(mobEffect));
             effect.addProperty("translationKey", mobEffect.getDescriptionId());
             effect.addProperty("color", mobEffect.getColor());
             effect.addProperty("instantaneous", mobEffect.isInstantenous());

--- a/DataGenerator/src/main/java/net/minestom/generators/ParticleGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/ParticleGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class ParticleGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject particles = new JsonObject();
-        for (var particleType : Registry.PARTICLE_TYPE) {
-            final var location = Registry.PARTICLE_TYPE.getKey(particleType);
+        var registry = BuiltInRegistries.PARTICLE_TYPE;
+        for (var particleType : registry) {
+            final var location = registry.getKey(particleType);
             JsonObject particle = new JsonObject();
-            particle.addProperty("id", Registry.PARTICLE_TYPE.getId(particleType));
+            particle.addProperty("id", registry.getId(particleType));
             particles.add(location.toString(), particle);
         }
         return particles;

--- a/DataGenerator/src/main/java/net/minestom/generators/PotionGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/PotionGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class PotionGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject potions = new JsonObject();
-        for (var potion : Registry.POTION) {
-            final var location = Registry.POTION.getKey(potion);
+        var registry = BuiltInRegistries.POTION;
+        for (var potion : registry) {
+            final var location = registry.getKey(potion);
             JsonObject effect = new JsonObject();
-            effect.addProperty("id", Registry.POTION.getId(potion));
+            effect.addProperty("id", registry.getId(potion));
             // TODO add effects
             potions.add(location.toString(), effect);
         }

--- a/DataGenerator/src/main/java/net/minestom/generators/SoundGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/SoundGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class SoundGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject sounds = new JsonObject();
-        for (var soundEvent : Registry.SOUND_EVENT) {
-            final var location = Registry.SOUND_EVENT.getKey(soundEvent);
+        var registry = BuiltInRegistries.SOUND_EVENT;
+        for (var soundEvent : registry) {
+            final var location = registry.getKey(soundEvent);
             JsonObject sound = new JsonObject();
-            sound.addProperty("id", Registry.SOUND_EVENT.getId(soundEvent));
+            sound.addProperty("id", registry.getId(soundEvent));
             sounds.add(location.toString(), sound);
         }
         return sounds;

--- a/DataGenerator/src/main/java/net/minestom/generators/VillagerProfessionGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/VillagerProfessionGenerator.java
@@ -1,7 +1,7 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minestom.datagen.DataGenerator;
@@ -10,13 +10,15 @@ public final class VillagerProfessionGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject villagerProfessions = new JsonObject();
-        for (var villagerProfession : Registry.VILLAGER_PROFESSION) {
-            final var location = Registry.VILLAGER_PROFESSION.getKey(villagerProfession);
+        var registry = BuiltInRegistries.VILLAGER_PROFESSION;
+        var soundEventRegistry = BuiltInRegistries.SOUND_EVENT;
+        for (var villagerProfession : registry) {
+            final var location = registry.getKey(villagerProfession);
             JsonObject villagerProfessionJson = new JsonObject();
-            villagerProfessionJson.addProperty("id", Registry.VILLAGER_PROFESSION.getId(villagerProfession));
+            villagerProfessionJson.addProperty("id", registry.getId(villagerProfession));
             SoundEvent workSound = villagerProfession.workSound();
             if (workSound != null) {
-                ResourceLocation workSoundRL = Registry.SOUND_EVENT.getKey(workSound);
+                ResourceLocation workSoundRL = soundEventRegistry.getKey(workSound);
                 if (workSoundRL != null) {
                     villagerProfessionJson.addProperty("workSound", workSoundRL.toString());
                 }

--- a/DataGenerator/src/main/java/net/minestom/generators/VillagerTypeGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/VillagerTypeGenerator.java
@@ -1,17 +1,18 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonObject;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minestom.datagen.DataGenerator;
 
 public final class VillagerTypeGenerator extends DataGenerator {
     @Override
     public JsonObject generate() {
         JsonObject villagerTypes = new JsonObject();
-        for (var villagerType : Registry.VILLAGER_TYPE) {
-            final var location = Registry.VILLAGER_TYPE.getKey(villagerType);
+        var registry = BuiltInRegistries.VILLAGER_TYPE;
+        for (var villagerType : registry) {
+            final var location = registry.getKey(villagerType);
             JsonObject villagerTypeJson = new JsonObject();
-            villagerTypeJson.addProperty("id", Registry.VILLAGER_TYPE.getId(villagerType));
+            villagerTypeJson.addProperty("id", registry.getId(villagerType));
             villagerTypes.add(location.toString(), villagerTypeJson);
         }
         return villagerTypes;

--- a/DataGenerator/src/main/java/net/minestom/utils/ResourceUtils.java
+++ b/DataGenerator/src/main/java/net/minestom/utils/ResourceUtils.java
@@ -1,0 +1,67 @@
+package net.minestom.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.jar.JarFile;
+
+public class ResourceUtils {
+
+    private ResourceUtils() {}
+
+    /**
+     * Get a resource listing from within a jar file
+     * @param clazz The class to use the {@link ClassLoader} of
+     * @param path The path within the classpath to list resources from
+     * @return An array containing all the path of all resources within the specified directory
+     * @throws URISyntaxException
+     * @throws IOException
+     */
+    public static String[] getResourceListing(Class clazz, String path) throws URISyntaxException, IOException {
+        var dirURL = clazz.getClassLoader().getResource(path);
+
+        // list use File#list in case path is just a regular file
+        if (dirURL != null && dirURL.getProtocol().equals("file")) {
+            return new File(dirURL.toURI()).list();
+        }
+
+        if (dirURL == null) {
+            var me = clazz.getName().replace(".", "/")+".class";
+            dirURL = clazz.getClassLoader().getResource(me);
+        }
+
+        // dirURL should not be null at this point
+        assert dirURL != null;
+
+        if (dirURL.getProtocol().equals("jar")) {
+            // strip out jar file from dirURL
+            var jarPath = dirURL.getPath().substring(5, dirURL.getPath().indexOf("!"));
+
+            try (var jar = new JarFile(URLDecoder.decode(jarPath, StandardCharsets.UTF_8))) {
+                // get all files within the jar
+                var entries = jar.entries();
+                var result = new HashSet<>();
+
+                while(entries.hasMoreElements()) {
+                    var name = entries.nextElement().getName();
+                    if (name.startsWith(path)) {
+                        var entry = name.substring(path.length());
+                        int checkSubdir = entry.indexOf("/");
+                        if (checkSubdir >= 0) {
+                            entry = entry.substring(0, checkSubdir);
+                        }
+                        result.add(entry);
+                    }
+                }
+
+                return result.toArray(new String[result.size()]);
+            }
+        }
+
+        throw new UnsupportedOperationException("Unable to list files for URL " + dirURL);
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-mcVersion=22w43a
+mcVersion=1.19.3


### PR DESCRIPTION
This PR adds support for Minecraft 1.19.3. Since biomes and dimension types don't have a built in registry anymore, those are now read directly from json files from the `net.minecraft:server` package. All other generators now use `net.minecraft.core.registries.BuiltInRegistries` instead of `net.minecraft.core.Registry`.