### PR TITLE
Fix generation of attributes

### DIFF
--- a/DataGenerator/src/main/java/net/minestom/generators/AttributeGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/AttributeGenerator.java
@@ -11,7 +11,7 @@ public final class AttributeGenerator extends DataGenerator {
         JsonObject attributes = new JsonObject();
         var registry = BuiltInRegistries.ATTRIBUTE;
         for (var attribute : registry) {
-            final var location = registry.key().location();
+            final var location = registry.getKey(attribute);
             JsonObject attributeJson = new JsonObject();
             attributeJson.addProperty("translationKey", attribute.getDescriptionId());
             attributeJson.addProperty("defaultValue", attribute.getDefaultValue());


### PR DESCRIPTION
This PR fixes the generation of attributes from Minecraft. It is generally very small, as it only fixes one call. 
It is already tested in our fork and functional.

The attribute structure must be rebuilt for this in Minestom
