### PR TITLE
Fix FeatureFlagGenerator.java to generate in the correct format

### DIFF
--- a/DataGenerator/src/main/java/net/minestom/datagen/DataGenType.java
+++ b/DataGenerator/src/main/java/net/minestom/datagen/DataGenType.java
@@ -19,6 +19,7 @@ public enum DataGenType {
     CUSTOM_STATISTICS("custom_statistics", new CustomStatisticGenerator()),
     DYE_COLORS("dye_colors", new DyeColorGenerator()),
     ENTITIES("entities", new EntityGenerator()),
+    FEATURE_FLAGS("feature_flags", new FeatureFlagGenerator()),
     FLUIDS("fluids", new FluidGenerator()),
     GAME_EVENTS("game_events", new GameEventGenerator()),
     MATERIALS("items", new MaterialGenerator()),

--- a/DataGenerator/src/main/java/net/minestom/generators/FeatureFlagGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/FeatureFlagGenerator.java
@@ -1,6 +1,7 @@
 package net.minestom.generators;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minestom.datagen.DataGenerator;
@@ -9,12 +10,15 @@ import java.util.Set;
 
 public final class FeatureFlagGenerator extends DataGenerator {
     @Override
-    public JsonArray generate() throws Exception {
-        JsonArray flags = new JsonArray();
+    public JsonObject generate() throws Exception {
+        JsonObject flags = new JsonObject();
 
         Set<ResourceLocation> featureFlags = FeatureFlags.REGISTRY.toNames(FeatureFlags.REGISTRY.allFlags());
+        int idCounter = 0;
         for (ResourceLocation namespace : featureFlags) {
-            flags.add(namespace.toString());
+            JsonObject flag = new JsonObject();
+            flag.addProperty("id", idCounter++);
+            flags.add(namespace.toString(), flag);
         }
 
         return flags;

--- a/DataGenerator/src/main/java/net/minestom/generators/FeatureFlagGenerator.java
+++ b/DataGenerator/src/main/java/net/minestom/generators/FeatureFlagGenerator.java
@@ -1,0 +1,22 @@
+package net.minestom.generators;
+
+import com.google.gson.JsonArray;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.flag.FeatureFlags;
+import net.minestom.datagen.DataGenerator;
+
+import java.util.Set;
+
+public final class FeatureFlagGenerator extends DataGenerator {
+    @Override
+    public JsonArray generate() throws Exception {
+        JsonArray flags = new JsonArray();
+
+        Set<ResourceLocation> featureFlags = FeatureFlags.REGISTRY.toNames(FeatureFlags.REGISTRY.allFlags());
+        for (ResourceLocation namespace : featureFlags) {
+            flags.add(namespace.toString());
+        }
+
+        return flags;
+    }
+}


### PR DESCRIPTION
I naively thought I could generate it as a JsonArray instead of a JsonObject, but that backfired so I rewrote it to do it how I should've in the first place. This needs to be merged and used in Minestom before [this PR](https://github.com/Minestom/Minestom/pull/2201) can be merged.